### PR TITLE
Add standalone Three.js vineyard pruning MVP

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Vineyard Winter Pruning 3D MVP</title>
+<style>
+  :root {
+    --bg: #111;
+    --panel-bg: #222;
+    --text: #eee;
+    --accent: #f44336;
+  }
+  body[data-theme="light"] {
+    --bg: #fafafa;
+    --panel-bg: #fff;
+    --text: #111;
+    --accent: #d32f2f;
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: sans-serif;
+    display: flex;
+    height: 100vh;
+    overflow: hidden;
+  }
+  #controls {
+    width: 260px;
+    background: var(--panel-bg);
+    padding: 10px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  #stage { flex: 1; }
+  label { display: block; margin-top: 4px; }
+  input[type=number] { width: 70px; }
+  #pendingBadge {
+    background: var(--accent);
+    border-radius: 10px;
+    padding: 0 6px;
+    color: white;
+    font-size: 12px;
+    vertical-align: middle;
+  }
+  button { margin-top: 4px; }
+  #robot { display: none; }
+</style>
+</head>
+<body data-theme="dark">
+<div id="controls">
+  <button id="themeToggle">Toggle Theme</button>
+  <div>
+    <label>Rows <input type="number" id="rows" value="2" min="1" max="10"></label>
+    <label>Vines/Row <input type="number" id="vinesPerRow" value="4" min="1" max="12"></label>
+    <button id="applyLayout">Apply Layout</button>
+  </div>
+  <div>
+    <label>Selected row <input type="number" id="selRow" value="0" min="0"></label>
+    <label>Selected vine <input type="number" id="selVine" value="0" min="0"></label>
+    <button id="centerSelect">Center & Select</button>
+  </div>
+  <div>
+    <label>Zoom <input type="range" id="zoom" min="3" max="25" value="12"></label>
+  </div>
+  <div>
+    <button id="execCuts">Execute Cuts (Enter)</button>
+    <button id="undoCut">Undo Last (Backspace)</button>
+    <button id="clearCuts">Clear Pending (R)</button>
+    <button id="resetLearned">Reset Learned Data</button>
+  </div>
+  <div>Pending: <span id="pendingBadge">0</span></div>
+  <div id="learningStats">Learning stats</div>
+</div>
+<div id="stage"></div>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+
+// === Config ===
+const state = {
+  rows: 2,
+  vinesPerRow: 4,
+  vines: [], // array of vine groups
+  selected: {row:0, vine:0},
+  pendingCuts: [], // {cane, t, pos, marker}
+  storedCuts: JSON.parse(localStorage.getItem('vine_pruning_cuts_3d_v2_curves_with_buds')||'[]')
+};
+
+// === Scene Setup ===
+const renderer = new THREE.WebGLRenderer({antialias:true});
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(window.innerWidth-260, window.innerHeight);
+document.getElementById('stage').appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(50, (window.innerWidth-260)/window.innerHeight, 0.1, 1000);
+let theta=0.5, phi=1.0, radius=12, target=new THREE.Vector3();
+
+// Lights
+scene.add(new THREE.HemisphereLight(0xffffff,0x222222,0.9));
+scene.add(new THREE.DirectionalLight(0xffffff,0.6));
+
+// Hover marker (scissors as simple red X)
+const hoverMarker = new THREE.Mesh(
+  new THREE.PlaneGeometry(0.4,0.4),
+  new THREE.MeshBasicMaterial({color:0xff0000, side:THREE.DoubleSide, transparent:true, opacity:0.8})
+);
+hoverMarker.visible=false;
+scene.add(hoverMarker);
+
+// Robot arm
+const robot = new THREE.Group();
+const base = new THREE.Mesh(new THREE.CylinderGeometry(0.2,0.2,0.4,16), new THREE.MeshStandardMaterial({color:0x555555}));
+base.position.y=0.2;
+const link = new THREE.Mesh(new THREE.CylinderGeometry(0.07,0.07,1.5,12), new THREE.MeshStandardMaterial({color:0x777777}));
+link.geometry.translate(0,0.75,0);
+const blade = new THREE.Mesh(new THREE.BoxGeometry(0.1,0.02,0.3), new THREE.MeshStandardMaterial({color:0xcc0000}));
+blade.position.y=1.5;
+robot.add(base); robot.add(link); robot.add(blade);
+robot.visible=false;
+scene.add(robot);
+
+// === Helpers ===
+function updateCamera(){
+  const x = radius*Math.sin(phi)*Math.cos(theta);
+  const y = radius*Math.cos(phi);
+  const z = radius*Math.sin(phi)*Math.sin(theta);
+  camera.position.set(x+target.x,y+target.y,z+target.z);
+  camera.lookAt(target);
+  renderer.render(scene,camera);
+}
+updateCamera();
+
+function themeUpdate(){
+  const bg = getComputedStyle(document.body).getPropertyValue('--bg');
+  renderer.setClearColor(new THREE.Color(bg.trim()));
+}
+
+themeUpdate();
+
+// === Vineyard Building ===
+function clearVineyard(){
+  state.vines.forEach(v=>scene.remove(v.group));
+  state.vines=[];
+}
+
+function buildVineyard(){
+  clearVineyard();
+  const rowSpacing=5, vineSpacing=4;
+  for(let r=0;r<state.rows;r++){
+    for(let i=0;i<state.vinesPerRow;i++){
+      const g=new THREE.Group();
+      g.position.set(i*vineSpacing,0,r*rowSpacing);
+      scene.add(g);
+      const vine={group:g, canes:[], cordonCenter:new THREE.Vector3(), index:{row:r,vine:i}};
+      buildVine(g,vine);
+      state.vines.push(vine);
+    }
+  }
+}
+
+function buildVine(group,vine){
+  const barkMat=new THREE.MeshStandardMaterial({color:0x6d4c41, roughness:0.9});
+  const metalMat=new THREE.MeshStandardMaterial({color:0x888888, metalness:0.8, roughness:0.3});
+  // trunk
+  let y=0;
+  for(let i=0;i<4;i++){
+    const radius=0.15-0.02*i;
+    const cyl=new THREE.Mesh(new THREE.CylinderGeometry(radius*1.2,radius,0.4,8), barkMat);
+    cyl.position.set((Math.random()-0.5)*0.1,y+0.2,(Math.random()-0.5)*0.1);
+    group.add(cyl);
+    y+=0.4;
+  }
+  // cordon
+  const cPts=[];
+  for(let i=-2;i<=2;i++){
+    cPts.push(new THREE.Vector3(i*0.5,1.5+Math.sin(i*0.5)*0.1,0));
+  }
+  const cordonCurve=new THREE.CatmullRomCurve3(cPts);
+  const cordonGeo=new THREE.TubeGeometry(cordonCurve,32,0.07,8,false);
+  const cordon=new THREE.Mesh(cordonGeo,barkMat);
+  group.add(cordon);
+  vine.cordonCenter=cordonCurve.getPoint(0.5);
+  // spurs + canes
+  const spurCount=6;
+  for(let s=0;s<spurCount;s++){
+    const t=s/(spurCount-1);
+    const pos=cordonCurve.getPoint(t);
+    const tangent=cordonCurve.getTangent(t).normalize();
+    const up=new THREE.Vector3(0,1,0);
+    const normal=new THREE.Vector3().crossVectors(up,tangent).normalize();
+    const spurCurve=new THREE.CatmullRomCurve3([
+      pos,
+      pos.clone().add(normal.clone().multiplyScalar(0.2)),
+      pos.clone().add(normal.clone().multiplyScalar(0.3)).add(new THREE.Vector3(0,0.3,0))
+    ]);
+    const spurGeo=new THREE.TubeGeometry(spurCurve,16,0.05,6,false);
+    const spur=new THREE.Mesh(spurGeo,barkMat);
+    group.add(spur);
+    // cane
+    const dir=Math.random()<0.5?-1:1;
+    const canePts=[spurCurve.getPoint(1)];
+    const len=3+Math.random()*2;
+    const mid=spurCurve.getPoint(1).clone().add(new THREE.Vector3(dir*len*0.3,0.3,len*0.3*(Math.random()-0.5)));
+    canePts.push(mid);
+    canePts.push(spurCurve.getPoint(1).clone().add(new THREE.Vector3(dir*len,0,0)));
+    const caneCurve=new THREE.CatmullRomCurve3(canePts);
+    const caneGeo=new THREE.TubeGeometry(caneCurve,96,0.03,6,false);
+    const cane=new THREE.Mesh(caneGeo,barkMat);
+    cane.geometry.computeBoundingSphere();
+    group.add(cane);
+    // buds
+    const buds=[];
+    const budCount=4+Math.floor(Math.random()*5);
+    for(let b=1;b<=budCount;b++){
+      const tBud=b/(budCount+1);
+      const budPos=caneCurve.getPoint(tBud);
+      const bud=new THREE.Mesh(new THREE.SphereGeometry(0.05,8,8), new THREE.MeshStandardMaterial({color:0xA8794D}));
+      bud.position.copy(budPos);
+      group.add(bud);
+      buds.push({mesh:bud,t:tBud});
+    }
+    vine.canes.push({mesh:cane, curve:caneCurve, tMax:1, buds});
+  }
+  // trellis: posts and wires
+  const postMat=metalMat;
+  const wireMat=metalMat;
+  const post1=new THREE.Mesh(new THREE.CylinderGeometry(0.05,0.05,2,8),postMat);
+  post1.position.set(-3,1,0);
+  const post2=post1.clone();
+  post2.position.x=3;
+  group.add(post1); group.add(post2);
+  const wireGeo=new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(-3,1.5,0),new THREE.Vector3(3,1.5,0)]);
+  const wire=new THREE.Line(wireGeo,new THREE.LineBasicMaterial({color:0x888888}));
+  group.add(wire);
+}
+
+// === Interaction ===
+const raycaster=new THREE.Raycaster();
+const pointer=new THREE.Vector2();
+function onPointerMove(e){
+  const rect=renderer.domElement.getBoundingClientRect();
+  pointer.x=((e.clientX-rect.left)/rect.width)*2-1;
+  pointer.y=-((e.clientY-rect.top)/rect.height)*2+1;
+  raycaster.setFromCamera(pointer,camera);
+  const meshes=[];
+  state.vines.forEach(v=>v.canes.forEach(c=>meshes.push(c.mesh)));
+  const hits=raycaster.intersectObjects(meshes,false);
+  if(hits.length>0){
+    const hit=hits[0];
+    const cane=state.vines.find(v=>v.canes.find(c=>c.mesh===hit.object)).canes.find(c=>c.mesh===hit.object);
+    const t=findNearestT(cane,hit.point);
+    const pos=cane.curve.getPoint(t);
+    const tangent=cane.curve.getTangent(t);
+    hoverMarker.position.copy(pos);
+    const q=new THREE.Quaternion();
+    q.setFromUnitVectors(new THREE.Vector3(0,0,1),tangent);
+    hoverMarker.quaternion.copy(q);
+    hoverMarker.visible=true;
+    hoverMarker.userData={cane,t,pos};
+  }else{
+    hoverMarker.visible=false;
+  }
+}
+function findNearestT(cane, point){
+  let bestT=0,bestDist=Infinity;
+  const samples=50;
+  for(let i=0;i<=samples;i++){
+    const t=i/samples*cane.tMax;
+    const p=cane.curve.getPoint(t);
+    const d=p.distanceToSquared(point);
+    if(d<bestDist){bestDist=d;bestT=t;}
+  }
+  // refine
+  let a=Math.max(0,bestT-0.05), b=Math.min(cane.tMax,bestT+0.05);
+  for(let i=0;i<10;i++){
+    const t1=a+(b-a)/3, t2=b-(b-a)/3;
+    const d1=cane.curve.getPoint(t1).distanceToSquared(point);
+    const d2=cane.curve.getPoint(t2).distanceToSquared(point);
+    if(d1<d2){b=t2;} else {a=t1;}
+  }
+  return (a+b)/2;
+}
+
+renderer.domElement.addEventListener('pointermove',onPointerMove);
+renderer.domElement.addEventListener('click',()=>{
+  if(!hoverMarker.visible) return;
+  const {cane,t,pos}=hoverMarker.userData;
+  const marker=new THREE.Mesh(new THREE.SphereGeometry(0.06,8,8), new THREE.MeshBasicMaterial({color:0xff0000}));
+  marker.position.copy(pos);
+  scene.add(marker);
+  state.pendingCuts.push({cane,t,pos,marker});
+  updatePending();
+});
+
+function updatePending(){
+  document.getElementById('pendingBadge').textContent=state.pendingCuts.length;
+}
+
+function undoLast(){
+  const cut=state.pendingCuts.pop();
+  if(cut){scene.remove(cut.marker);} updatePending();
+}
+function clearPending(){state.pendingCuts.forEach(c=>scene.remove(c.marker));state.pendingCuts=[];updatePending();}
+
+// Execute cuts with robot
+function executeCuts(){
+  if(state.pendingCuts.length===0) return;
+  robot.visible=true;
+  let i=0; let phase='move'; let targetPos,cut; let lastTime=null;
+  const speed=8; // units/sec
+  function step(time){
+    if(!lastTime) lastTime=time; const dt=(time-lastTime)/1000; lastTime=time;
+    if(i>=state.pendingCuts.length){
+      robot.visible=false;
+      clearPending();
+      renderer.setAnimationLoop(renderLoop);
+      return;
+    }
+    cut=state.pendingCuts[i];
+    if(phase==='move'){
+      targetPos=cut.pos;
+      const dir=targetPos.clone().sub(robot.position);
+      const dist=dir.length();
+      if(dist<0.05){phase='cut';} else {robot.position.add(dir.normalize().multiplyScalar(speed*dt));}
+    }else if(phase==='cut'){
+      applyCut(cut);
+      saveCut(cut);
+      i++; phase='move';
+    }
+    renderer.render(scene,camera);
+  }
+  renderer.setAnimationLoop(step);
+}
+
+function applyCut(cut){
+  const cane=cut.cane;
+  cane.tMax=cut.t;
+  const geo=new THREE.TubeGeometry(cane.curve,96,0.03,6,false,0,cane.tMax);
+  cut.cane.mesh.geometry.dispose();
+  cut.cane.mesh.geometry=geo;
+  geo.computeBoundingSphere();
+  cane.buds.forEach(b=>{b.mesh.visible=b.t<=cane.tMax;});
+}
+function saveCut(cut){
+  const pos=cut.pos.clone().sub(cut.cane.mesh.parent.position);
+  state.storedCuts.push(pos.toArray());
+  localStorage.setItem('vine_pruning_cuts_3d_v2_curves_with_buds',JSON.stringify(state.storedCuts));
+  document.getElementById('learningStats').textContent=`Learning stats: ${state.storedCuts.length} cuts`;
+}
+
+// Recommended zones
+const recGroup=new THREE.Group();
+scene.add(recGroup);
+function updateRecommendations(){
+  recGroup.clear();
+  if(state.storedCuts.length<20) return;
+  const vine=getSelectedVine();
+  const counts={};
+  const cell=0.5; // grid size
+  state.storedCuts.forEach(a=>{
+    const p=new THREE.Vector3().fromArray(a);
+    const x=Math.round(p.x/cell), z=Math.round(p.z/cell);
+    const key=x+','+z; counts[key]=(counts[key]||0)+1;
+  });
+  Object.entries(counts).forEach(([k,c])=>{
+    const [x,z]=k.split(',').map(Number);
+    const ring=new THREE.Mesh(new THREE.RingGeometry(0.2,0.25,16), new THREE.MeshBasicMaterial({color:0xff0000, transparent:true, opacity:0.5, side:THREE.DoubleSide}));
+    ring.position.set(x*cell+vine.group.position.x,1.5,z*cell+vine.group.position.z);
+    ring.rotation.x=-Math.PI/2;
+    recGroup.add(ring);
+  });
+}
+
+// Camera orbit controls
+let isDragging=false, prevX=0,prevY=0;
+renderer.domElement.addEventListener('mousedown',e=>{isDragging=true;prevX=e.clientX;prevY=e.clientY;});
+window.addEventListener('mouseup',()=>isDragging=false);
+window.addEventListener('mousemove',e=>{
+  if(!isDragging) return;
+  const dx=(e.clientX-prevX)/window.innerWidth;
+  const dy=(e.clientY-prevY)/window.innerHeight;
+  theta-=dx*3; phi-=dy*3; phi=Math.max(0.1,Math.min(Math.PI-0.1,phi));
+  prevX=e.clientX; prevY=e.clientY; updateCamera();
+});
+renderer.domElement.addEventListener('wheel',e=>{radius*=1+e.deltaY*0.001;radius=Math.max(3,Math.min(40,radius));document.getElementById('zoom').value=radius;updateCamera();});
+
+// keyboard
+window.addEventListener('keydown',e=>{
+  if(e.key==='Enter'){executeCuts();}
+  if(e.key==='Backspace'){undoLast();}
+  if(e.key.toLowerCase()==='r'){clearPending();}
+});
+
+// selection & double click
+renderer.domElement.addEventListener('dblclick',e=>{
+  raycaster.setFromCamera(pointer,camera);
+  const groups=state.vines.map(v=>v.group);
+  const hits=raycaster.intersectObjects(groups,true);
+  if(hits.length>0){
+    let obj=hits[0].object;
+    while(obj && !groups.includes(obj)){obj=obj.parent;}
+    const vine=state.vines.find(v=>v.group===obj);
+    if(vine){
+      state.selected=vine.index;
+      document.getElementById('selRow').value=vine.index.row;
+      document.getElementById('selVine').value=vine.index.vine;
+      centerSelected();
+    }
+  }
+});
+
+function getSelectedVine(){
+  return state.vines.find(v=>v.index.row==state.selected.row && v.index.vine==state.selected.vine);
+}
+function centerSelected(){
+  const vine=getSelectedVine();
+  if(vine){target.copy(vine.group.position.clone().add(vine.cordonCenter));updateCamera();updateRecommendations();}
+}
+
+// === UI events ===
+document.getElementById('themeToggle').onclick=()=>{
+  const b=document.body;b.dataset.theme=b.dataset.theme==='dark'?'light':'dark';themeUpdate();renderer.render(scene,camera);
+};
+document.getElementById('applyLayout').onclick=()=>{state.rows=+document.getElementById('rows').value;state.vinesPerRow=+document.getElementById('vinesPerRow').value;buildVineyard();};
+document.getElementById('centerSelect').onclick=()=>{state.selected.row=+document.getElementById('selRow').value;state.selected.vine=+document.getElementById('selVine').value;centerSelected();};
+document.getElementById('zoom').oninput=e=>{radius=+e.target.value;updateCamera();};
+document.getElementById('execCuts').onclick=executeCuts;
+document.getElementById('undoCut').onclick=undoLast;
+document.getElementById('clearCuts').onclick=clearPending;
+document.getElementById('resetLearned').onclick=()=>{localStorage.removeItem('vine_pruning_cuts_3d_v2_curves_with_buds');state.storedCuts=[];document.getElementById('learningStats').textContent='Learning stats';updateRecommendations();};
+
+// Initial
+buildVineyard();
+centerSelected();
+updatePending();
+
+// render loop
+function renderLoop(time){
+  renderer.render(scene,camera);
+}
+renderer.setAnimationLoop(renderLoop);
+
+window.addEventListener('resize',()=>{
+  renderer.setSize(window.innerWidth-260, window.innerHeight);
+  camera.aspect=(window.innerWidth-260)/window.innerHeight;camera.updateProjectionMatrix();
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `vineyard_pruning_3d.html` implementing a standalone Three.js demo for vineyard pruning with custom orbit controls, vineyard generation, and robot-cut animation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68970e3ba5ac83229c73bc8bce4746c7