### PR TITLE
Avoid altering vine structure during cut recording

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -362,7 +362,6 @@ function recordCuts(){
   state.pendingCuts.forEach(cut=>{
     const idx=findVineIndex(cut.cane);
     records.push({row:idx.row, vine:idx.vine, x:cut.pos.x, y:cut.pos.y, z:cut.pos.z});
-    applyCut(cut);
     scene.remove(cut.marker);
   });
   state.pendingCuts=[];


### PR DESCRIPTION
## Summary
- prevent `recordCuts` from mutating vine geometry so real view remains intact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974ac9757c83228ed9e1dcf72cc2db