### PR TITLE
Prevent digital cuts from altering real vineyard view

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -179,6 +179,9 @@ function setViewMode(mode){
   robot.visible = false;
   hoverMarker.visible = false;
   clearPending();
+  if(mode==='real'){
+    buildVineyard();
+  }
   centerSelected();
   if(mode==='digital' && state.needsReapply){
     initCutFile().then(()=>{reapplyDigitalCuts();});


### PR DESCRIPTION
## Summary
- Rebuild vineyard when switching to real view so previously recorded cuts aren't shown on the real vine

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976192dd288322be842da3cff5940f