### PR TITLE
Fix cut file loading and replay feedback

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -390,11 +390,16 @@ function findVineIndex(cane){
 
 function parseCutFile(text){
   try{
-    const arr=JSON.parse(text);
-    return Array.isArray(arr)?arr:[];
-  }catch(e){
-    return text.trim().split('\n').filter(l=>l).map(l=>JSON.parse(l));
-  }
+    const arr = JSON.parse(text);
+    if(Array.isArray(arr)) return arr;
+  }catch(e){}
+  const result=[];
+  text.split('\n').forEach(line=>{
+    line=line.trim();
+    if(!line || line.startsWith('#')) return;
+    try{result.push(JSON.parse(line));}catch(err){/* ignore bad lines */}
+  });
+  return result;
 }
 
 async function initCutFile(){
@@ -504,6 +509,8 @@ async function recordCuts(){
       const text=await file.text();
       const data=parseCutFile(text);
       loadCuts(data);
+      const loadBtn=document.getElementById('loadCuts');
+      loadBtn.style.backgroundColor='lightgreen';
       document.getElementById('loadStatus').textContent=`Loaded ${data.length} cuts`;
     }catch(err){console.error(err);}
   }
@@ -672,7 +679,13 @@ document.getElementById('recordCuts').onclick=recordCuts;
 document.getElementById('loadCuts').onclick=loadCutFile;
 document.getElementById('replayCuts').onclick=async ()=>{
   if(state.pendingCuts.length===0){
-    await loadCutFile();
+    if(state.cutPlaybackHandle){
+      const file=await state.cutPlaybackHandle.getFile();
+      const text=await file.text();
+      loadCuts(parseCutFile(text));
+    }else{
+      await loadCutFile();
+    }
   }
   const count=state.pendingCuts.length;
   if(count===0) return;


### PR DESCRIPTION
## Summary
- Ignore commented lines when parsing cut files
- Highlight load button and show cut count after loading
- Reuse previously loaded cut file when replaying

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977061a8f88322b8097165a20a7ca4