### PR TITLE
Reset digital cut file when layout changes

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -664,6 +664,10 @@ document.getElementById('applyLayout').onclick=()=>{
   state.randomSeed=Math.floor(Math.random()*1e9);
   buildVineyard();
   centerSelected();
+  state.cutFileHandle=null;
+  state.cutPlaybackHandle=null;
+  state.cutLog=[];
+  clearPending();
 };
 document.getElementById('centerSelect').onclick=()=>{state.selected.row=+document.getElementById('selRow').value;state.selected.vine=+document.getElementById('selVine').value;centerSelected();};
 document.getElementById('zoom').oninput=e=>{radius=+e.target.value;updateCamera();};


### PR DESCRIPTION
## Summary
- Clear existing cut log and file handles whenever a new vineyard layout is applied
- Remove any pending cuts so digital twin refreshes correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689773fe480c8322b78b8cde5da75777