### PR TITLE
Avoid applying digital cuts to real vineyard

### DIFF
--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -195,6 +195,7 @@ function setViewMode(mode){
   }
   if(mode==='digital'){
     initCutFile();
+    reapplyDigitalCuts();
   }
   centerSelected();
 }
@@ -223,7 +224,7 @@ function buildVineyard(){
       state.vines.push(vine);
     }
   }
-  if(state.cutLog.length>0){
+  if(state.cutLog.length>0 && state.viewMode==='digital'){
     reapplyDigitalCuts();
   }
 }


### PR DESCRIPTION
## Summary
- Reapply digital cut log only in digital twin view to prevent unintended real-vineyard cuts
- Restore digital cuts after switching views by calling `reapplyDigitalCuts` when entering digital mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a36bcf1c8322ac7b336d4dd7af4d