### PR TITLE
feat: add rover arm cut replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# vineyardDemo
+# Vineyard Demo
+
+Interactive 3D vineyard pruning demo. The real vineyard view now includes a
+four‑wheel rover that drives between vines and uses a robotic arm to execute
+stored cuts during replay.
+

--- a/vineyard_pruning_3d.html
+++ b/vineyard_pruning_3d.html
@@ -149,15 +149,47 @@ const hoverMarker = new THREE.Mesh(
 hoverMarker.visible=false;
 scene.add(hoverMarker);
 
-// Robot arm
+// Rover with robotic arm
 const robot = new THREE.Group();
-const base = new THREE.Mesh(new THREE.CylinderGeometry(0.2,0.2,0.4,16), new THREE.MeshStandardMaterial({color:0x555555}));
-base.position.y=0.2;
-const link = new THREE.Mesh(new THREE.CylinderGeometry(0.07,0.07,1.5,12), new THREE.MeshStandardMaterial({color:0x777777}));
-link.geometry.translate(0,0.75,0);
-const blade = new THREE.Mesh(new THREE.BoxGeometry(0.1,0.02,0.3), new THREE.MeshStandardMaterial({color:0xcc0000}));
-blade.position.y=1.5;
-robot.add(base); robot.add(link); robot.add(blade);
+
+// chassis
+const chassis = new THREE.Mesh(
+  new THREE.BoxGeometry(0.6,0.2,0.4),
+  new THREE.MeshStandardMaterial({color:0x444444})
+);
+chassis.position.y=0.2;
+robot.add(chassis);
+
+// wheels
+const wheelGeo=new THREE.CylinderGeometry(0.1,0.1,0.05,16);
+wheelGeo.rotateZ(Math.PI/2);
+const wheelMat=new THREE.MeshStandardMaterial({color:0x222222});
+[[0.25,0.1,0.2],[-0.25,0.1,0.2],[0.25,0.1,-0.2],[-0.25,0.1,-0.2]].forEach(p=>{
+  const w=new THREE.Mesh(wheelGeo,wheelMat);
+  w.position.set(p[0],p[1],p[2]);
+  robot.add(w);
+});
+
+// robotic arm
+const arm=new THREE.Group();
+const armBaseHeight=0.35;
+arm.position.set(0,armBaseHeight,0);
+const link=new THREE.Mesh(new THREE.CylinderGeometry(0.05,0.05,1,12),
+  new THREE.MeshStandardMaterial({color:0x777777}));
+link.geometry.translate(0,0.5,0);
+const blade=new THREE.Mesh(new THREE.BoxGeometry(0.1,0.02,0.3),
+  new THREE.MeshStandardMaterial({color:0xcc0000}));
+blade.position.y=1;
+arm.add(link);
+arm.add(blade);
+robot.add(arm);
+
+// arm initial state
+const armRest=0.1;
+let armLength=armRest;
+link.scale.y=armLength;
+blade.position.y=armLength;
+
 robot.visible=false;
 scene.add(robot);
 
@@ -525,16 +557,21 @@ async function recordCuts(){
     state.cutPlaybackHandle=null;
   }
 
-// Execute cuts with robot
+// Execute cuts with rover and arm
 function executeCuts(onComplete){
   if(state.pendingCuts.length===0){
     if(onComplete) onComplete();
     return;
   }
   robot.visible=true;
-  let i=0; let phase='move'; let targetPos,cut; let lastTime=null;
-  const speed=8; // units/sec
-  robot.position.copy(state.pendingCuts[0].pos);
+  let i=0; let phase='move'; let cut; let lastTime=null;
+  const speed=4; // rover speed
+  const armSpeed=2;
+  armLength=armRest;
+  link.scale.y=armLength;
+  blade.position.y=armLength;
+  robot.position.set(state.pendingCuts[0].pos.x,0,state.pendingCuts[0].pos.z);
+  let armTargetLen=0; const armBase=new THREE.Vector3(0,armBaseHeight,0); let armTarget=new THREE.Vector3();
   function step(time){
     if(!lastTime) lastTime=time; const dt=(time-lastTime)/1000; lastTime=time;
     if(i>=state.pendingCuts.length){
@@ -547,18 +584,34 @@ function executeCuts(onComplete){
     }
     cut=state.pendingCuts[i];
     if(phase==='move'){
-      targetPos=cut.pos;
-      const dir=targetPos.clone().sub(robot.position);
+      const targetBase=new THREE.Vector3(cut.pos.x,0,cut.pos.z);
+      const dir=targetBase.clone().sub(robot.position);
       const dist=dir.length();
-      if(dist<0.05){phase='cut';}
-      else if(dist>15){robot.position.copy(targetPos);phase='cut';}
-      else {robot.position.add(dir.normalize().multiplyScalar(speed*dt));}
+      if(dist<0.05){
+        const local=robot.worldToLocal(cut.pos.clone());
+        armTarget.copy(local).sub(armBase);
+        arm.lookAt(local);
+        armTargetLen=armTarget.length();
+        phase='extend';
+      }else{
+        robot.position.add(dir.normalize().multiplyScalar(speed*dt));
+      }
+    }else if(phase==='extend'){
+      armLength=Math.min(armTargetLen,armLength+armSpeed*dt);
+      link.scale.y=armLength;
+      blade.position.y=armLength;
+      if(armLength>=armTargetLen){phase='cut';}
     }else if(phase==='cut'){
       applyCut(cut);
       saveCut(cut);
       const idx=findVineIndex(cut.cane);
       state.cutLog.push({row:idx.row, vine:idx.vine, x:cut.pos.x, y:cut.pos.y, z:cut.pos.z});
-      i++; phase='move';
+      phase='retract';
+    }else if(phase==='retract'){
+      armLength=Math.max(armRest,armLength-armSpeed*dt);
+      link.scale.y=armLength;
+      blade.position.y=armLength;
+      if(armLength<=armRest){i++; phase='move';}
     }
     renderer.render(scene,camera);
   }


### PR DESCRIPTION
## Summary
- add 4-wheel rover with robotic arm to execute cuts in real vineyard view
- animate rover driving between vines and extending arm during replay
- document rover-based cut replay in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ab497f008322b18d3e30dd22e2c4