### PR TITLE
fix: show vineyard platform

### DIFF
--- a/vineyard_platform.html
+++ b/vineyard_platform.html
@@ -42,7 +42,8 @@ button:focus{outline:1px solid #888}
 </style>
 </head>
 <body>
-<svg id="view" aria-label="Vineyard teleoperation view"></svg>
+<svg id="view" aria-label="Vineyard teleoperation view"
+     viewBox="-600 -200 4200 2000" preserveAspectRatio="xMidYMid meet"></svg>
 <div id="hud"></div>
 <div id="help" aria-label="Keyboard map"></div>
 <div id="log" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- ensure vineyard and platform visible by defining SVG viewBox

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68984c772b248322af79209384b5a1cf