### PR TITLE
Fix OrbitControls import path

### DIFF
--- a/vineyard_platform.html
+++ b/vineyard_platform.html
@@ -36,7 +36,7 @@ html,body{margin:0;height:100%;overflow:hidden;background:#111;color:#eee;font-f
 // Copyright (c) 2024
 
 import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
-import {OrbitControls} from 'https://unpkg.com/three@0.161.0/examples/jsm/controls/OrbitControls.js';
+import {OrbitControls} from 'https://unpkg.com/three@0.161.0/examples/jsm/controls/OrbitControls.js?module';
 
 // ---- constants ----
 const ROWS=6;            // number of rows


### PR DESCRIPTION
## Summary
- resolve module specifier error in vineyard platform by adding `?module` to OrbitControls CDN import

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68986e8478cc832285c59380e9d3240e