### PR TITLE
Add automatic row transfer controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Interactive 3D vineyard pruning demo. The real vineyard view now includes a
 four‑wheel rover that drives between vines and uses a robotic arm to execute
 stored cuts during replay.
 
+The platform also supports automatic row-to-row transfers. Enter a row number
+and press **Move** to send the rover up to the overhead rail, across to the
+selected row and back down ready for teleoperation.
+

--- a/vineyard_platform.html
+++ b/vineyard_platform.html
@@ -12,6 +12,8 @@ html,body{margin:0;height:100%;overflow:hidden;background:#111;color:#eee;font-f
 #buttons{position:absolute;bottom:4px;right:4px;display:flex;gap:4px}
 #buttons button{font-size:12px;padding:4px 6px}
 #sliders{position:absolute;top:4px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.4);padding:4px;border-radius:4px;font-size:12px;display:flex;gap:8px;align-items:center}
+#rowControls{position:absolute;bottom:40px;right:4px;display:flex;gap:4px;align-items:center;background:rgba(0,0,0,0.4);padding:4px;border-radius:4px;font-size:12px}
+#rowControls input{width:32px}
 </style>
 </head>
 <body>
@@ -26,6 +28,11 @@ html,body{margin:0;height:100%;overflow:hidden;background:#111;color:#eee;font-f
   <button id="btnWork">Work</button>
   <button id="btnDock">Dock</button>
   <button id="btnEstop">E-Stop</button>
+</div>
+<div id="rowControls">
+  <label for="rowInput">Row</label>
+  <input id="rowInput" type="number" min="0" max="5" value="0">
+  <button id="btnRowMove">Move</button>
 </div>
 <div id="sliders">
   <label>Carriage <input id="carriageSpeed" type="range" min="0.2" max="2" step="0.1" value="1"></label>
@@ -48,6 +55,8 @@ const WIRE1_Z=1.2;
 const WIRE2_Z=1.3;
 const OVERHEAD_Z=3.0;
 const HEADLAND_X=-2;     // X position of overhead traverse wire
+
+document.getElementById('rowInput').max=ROWS-1;
 
 // ---- renderer / scene / camera ----
 const renderer=new THREE.WebGLRenderer({antialias:true});
@@ -226,6 +235,7 @@ let transferY=OVERHEAD_Z; // used in transfer
 let estop=false;
 let toolMode='Pruner';
 let teleTarget=null;
+let autoTransfer=null;
 
 carriage.position.set(0,WIRE1_Z+0.05,currentRow*ROW_SPACING);
 
@@ -248,6 +258,10 @@ document.getElementById('btnTeleop').onclick=()=>{mode='Teleop';teleTarget=null;
 document.getElementById('btnWork').onclick=()=>{mode='Work';teleTarget=null;targetMarker.visible=false;logEvent('Work mode');};
 document.getElementById('btnDock').onclick=()=>{carriage.position.set(HEADLAND_X-1,0.25,-2);xPos=0;mode='Traverse';teleTarget=null;targetMarker.visible=false;logEvent('Dock');};
 document.getElementById('btnEstop').onclick=toggleEstop;
+document.getElementById('btnRowMove').onclick=()=>{
+  const row=parseInt(document.getElementById('rowInput').value,10);
+  startAutoTransfer(row);
+};
 
 let carriageSpeed=parseFloat(localStorage.getItem('carriageSpeed')||'1');
 let jointSpeed=parseFloat(localStorage.getItem('jointSpeed')||'30');
@@ -293,6 +307,55 @@ function attachRow(){
   currentRow=Math.round(zPos/ROW_SPACING);
   carriage.position.set(xPos,WIRE1_Z+0.05,currentRow*ROW_SPACING);
   logEvent('Traverse mode');
+}
+
+function startAutoTransfer(row){
+  if(row<0||row>=ROWS||row===currentRow) return;
+  teleTarget=null;targetMarker.visible=false;
+  autoTransfer={targetRow:row,phase:(xPos===HEADLAND_X?'up':'toHeadland')};
+  mode='AutoTransfer';
+  transferY=WIRE1_Z+0.05;
+  logEvent('Auto transfer to row '+row);
+}
+
+function updateAutoTransfer(dt){
+  if(!autoTransfer) return;
+  if(autoTransfer.phase==='toHeadland'){
+    const dir=HEADLAND_X-xPos;
+    const step=Math.sign(dir)*carriageSpeed*dt;
+    if(Math.abs(dir)<=Math.abs(step)){
+      xPos=HEADLAND_X;
+      autoTransfer.phase='up';
+    }else{
+      xPos+=step;
+    }
+    carriage.position.set(xPos,transferY,currentRow*ROW_SPACING);
+  }else if(autoTransfer.phase==='up'){
+    transferY=Math.min(OVERHEAD_Z,transferY+transferSpeed*dt);
+    carriage.position.set(xPos,transferY,currentRow*ROW_SPACING);
+    if(transferY>=OVERHEAD_Z) autoTransfer.phase='across';
+  }else if(autoTransfer.phase==='across'){
+    const targetZ=autoTransfer.targetRow*ROW_SPACING;
+    const dir=targetZ-zPos;
+    const step=Math.sign(dir)*carriageSpeed*dt;
+    if(Math.abs(dir)<=Math.abs(step)){
+      zPos=targetZ;
+      autoTransfer.phase='down';
+    }else{
+      zPos+=step;
+    }
+    carriage.position.set(xPos,transferY,zPos);
+  }else if(autoTransfer.phase==='down'){
+    transferY=Math.max(WIRE1_Z+0.05,transferY-transferSpeed*dt);
+    carriage.position.set(xPos,transferY,zPos);
+    if(transferY<=WIRE1_Z+0.05){
+      currentRow=autoTransfer.targetRow;
+      autoTransfer=null;
+      mode='Teleop';
+      carriage.position.set(xPos,WIRE1_Z+0.05,currentRow*ROW_SPACING);
+      logEvent(`Arrived at row ${currentRow}`);
+    }
+  }
 }
 
 renderer.domElement.addEventListener('click',e=>{
@@ -357,6 +420,8 @@ function animate(){
       zPos=THREE.MathUtils.clamp(zPos+zdir*carriageSpeed*dt,0,(ROWS-1)*ROW_SPACING);
       currentRow=Math.round(zPos/ROW_SPACING);
       carriage.position.set(xPos,transferY,zPos);
+    }else if(mode==='AutoTransfer'){
+      updateAutoTransfer(dt);
     }else if(mode==='Work'){
       let dir=0;
       if(keys['ArrowLeft'])dir=-1;


### PR DESCRIPTION
## Summary
- Add numeric row selector and Move button for automatic transfers between vineyard rows
- Implement AutoTransfer state to raise rover to overhead rail, traverse to selected row, and return to teleop mode
- Update documentation to describe automatic row-to-row transfer feature

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/vineyardDemo/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689896482204832296677e187a9e1165