### PR TITLE
Raise row rail height above vines

### DIFF
--- a/vineyard_platform.html
+++ b/vineyard_platform.html
@@ -61,8 +61,8 @@ let vines=41;           // vines per row
 const VINE_SPACING=2;   // meters between vines
 const ROW_SPACING=2.5;  // meters between rows
 const CORDON_Z=1.0;     // meters
-const WIRE1_Z=1.2;
-const WIRE2_Z=1.3;
+const WIRE1_Z=1.8;
+const WIRE2_Z=1.95;
 const OVERHEAD_Z=3.0;
 const HEADLAND_X=-2;    // X position of overhead traverse wire
 let rowLen=(vines-1)*VINE_SPACING;
@@ -123,7 +123,7 @@ function buildVineyard(){
       mesh.castShadow=true;mesh.receiveShadow=true;
       wires.add(mesh);
     }
-    const height=1.6;
+    const height=2.4;
     for(let i=0;i<=Math.ceil(rowLen/5);i++){
       const x=Math.min(i*5,rowLen);
       const radius=(x===0||x===rowLen)?0.06:0.04;


### PR DESCRIPTION
## Summary
- Increase row rail heights to keep vines below rail by scaling WIRE1_Z and WIRE2_Z by 1.5x.
- Extend trellis posts accordingly to support the higher rails.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a03059608322b70e9ec3a375eb2d