### PR TITLE
Add rail height slider and improve cut replay path

### DIFF
--- a/VineAndPlatform.html
+++ b/VineAndPlatform.html
@@ -39,6 +39,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    justify-content: center;
   }
   #layoutControls label {
     display: flex;
@@ -63,7 +64,7 @@
   }
   #stage { flex: 1; }
   label { display: block; margin-top: 4px; }
-  input[type=number] { width: 70px; }
+  input[type=number] { width: 70px; text-align: right; }
   #pendingBadge {
     background: var(--accent);
     border-radius: 10px;
@@ -101,6 +102,7 @@
 <div id="controls">
   <div id="railControls">
     <button id="toggleRailHeight">Toggle Rail Height</button>
+    <label>Rail Height <input type="range" id="railHeight" min="1" max="2" step="0.1" value="2"></label>
   </div>
     <div id="realControls" style="display:none">
     <label>Similarity <input type="range" id="similarity" min="0" max="1" step="0.1" value="0.5"></label>
@@ -765,14 +767,40 @@ function executeCuts(onComplete){
     return;
   }
   robot.visible=true;
-  let i=0; let phase='move'; let cut; let lastTime=null;
-  const speed=4; // platform speed
   Object.assign(armAngles,restAngles); applyAngles();
-  robot.position.set(state.pendingCuts[0].pos.x,0,state.pendingCuts[0].pos.z);
+  const firstIdx=findVineIndex(state.pendingCuts[0].cane);
+  robot.position.set(HEADLAND_X,transferY,firstIdx.row*ROW_SPACING);
+  const actions=[];
+  let currX=HEADLAND_X;
+  let currZ=firstIdx.row*ROW_SPACING;
+  actions.push({type:'move',x:0,z:currZ});
+  actions.push({type:'move',x:state.pendingCuts[0].pos.x,z:currZ});
+  actions.push({type:'cut',cut:state.pendingCuts[0]});
+  for(let j=1;j<state.pendingCuts.length;j++){
+    const next=state.pendingCuts[j];
+    const idx=findVineIndex(next.cane);
+    const targetZ=idx.row*ROW_SPACING;
+    const targetX=next.pos.x;
+    if(Math.abs(currZ-targetZ)>0.01){
+      if(Math.abs(currX)>0.01) actions.push({type:'move',x:0,z:currZ});
+      actions.push({type:'move',x:HEADLAND_X,z:currZ});
+      actions.push({type:'move',x:HEADLAND_X,z:targetZ});
+      actions.push({type:'move',x:0,z:targetZ});
+      currX=0; currZ=targetZ;
+    }
+    actions.push({type:'move',x:targetX,z:currZ});
+    actions.push({type:'cut',cut:next});
+    currX=targetX;
+  }
+  let actionIndex=0;
+  let currentCut=null;
+  let cutPhase='extend';
   let targetAngles=Object.assign({},restAngles);
+  let lastTime=null;
+  const speed=4; // platform speed
   function step(time){
     if(!lastTime) lastTime=time; const dt=(time-lastTime)/1000; lastTime=time;
-    if(i>=state.pendingCuts.length){
+    if(actionIndex>=actions.length){
       robot.visible=true;
       clearPending();
       renderer.setAnimationLoop(renderLoop);
@@ -780,30 +808,39 @@ function executeCuts(onComplete){
       if(onComplete) onComplete();
       return;
     }
-    cut=state.pendingCuts[i];
-    if(phase==='move'){
-      const targetBase=new THREE.Vector3(cut.pos.x,0,cut.pos.z);
+    const action=actions[actionIndex];
+    if(action.type==='move'){
+      const targetBase=new THREE.Vector3(action.x,transferY,action.z);
       const dir=targetBase.clone().sub(robot.position);
       const dist=dir.length();
       if(dist<0.05){
-        const local=robot.worldToLocal(cut.pos.clone());
-        targetAngles=solveIK(local);
-        phase='extend';
+        actionIndex++;
       }else{
         robot.position.add(dir.normalize().multiplyScalar(speed*dt));
       }
-    }else if(phase==='extend'){
-      moveAnglesTowards(targetAngles,dt);
-      if(anglesClose(armAngles,targetAngles)) phase='cut';
-    }else if(phase==='cut'){
-      applyCut(cut);
-      saveCut(cut);
-      const idx=findVineIndex(cut.cane);
-      state.cutLog.push({row:idx.row, vine:idx.vine, x:cut.pos.x, y:cut.pos.y, z:cut.pos.z});
-      phase='retract';
-    }else if(phase==='retract'){
-      moveAnglesTowards(restAngles,dt);
-      if(anglesClose(armAngles,restAngles)){i++; phase='move';}
+    }else if(action.type==='cut'){
+      if(!currentCut){
+        currentCut=action.cut;
+        const local=robot.worldToLocal(currentCut.pos.clone());
+        targetAngles=solveIK(local);
+        cutPhase='extend';
+      }
+      if(cutPhase==='extend'){
+        moveAnglesTowards(targetAngles,dt);
+        if(anglesClose(armAngles,targetAngles)) cutPhase='cut';
+      }else if(cutPhase==='cut'){
+        applyCut(currentCut);
+        saveCut(currentCut);
+        const idx=findVineIndex(currentCut.cane);
+        state.cutLog.push({row:idx.row, vine:idx.vine, x:currentCut.pos.x, y:currentCut.pos.y, z:currentCut.pos.z});
+        cutPhase='retract';
+      }else if(cutPhase==='retract'){
+        moveAnglesTowards(restAngles,dt);
+        if(anglesClose(armAngles,restAngles)){
+          currentCut=null;
+          actionIndex++;
+        }
+      }
     }
     renderer.render(scene,camera);
   }
@@ -1026,6 +1063,11 @@ document.getElementById('applyLayout').onclick=()=>{
 };
 document.getElementById('toggleRailHeight').onclick=()=>{
   railHeightScale = railHeightScale === 1 ? 2 : 1;
+  document.getElementById('railHeight').value = railHeightScale;
+  updateRailHeights(railHeightScale);
+};
+document.getElementById('railHeight').oninput=e=>{
+  railHeightScale = +e.target.value;
   updateRailHeights(railHeightScale);
 };
 document.getElementById('centerSelect').onclick=()=>{state.selected.row=+document.getElementById('selRow').value;state.selected.vine=+document.getElementById('selVine').value;centerSelected();};


### PR DESCRIPTION
## Summary
- Align top layout controls and right-justify numeric inputs
- Introduce rail height slider with synchronized toggle control
- Replay cuts from rail height, traversing rails and transfer paths before each cut

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68999eba4e5883229cd6810313bf24e0