### PR TITLE
Require cutter to reach target in real vineyard

### DIFF
--- a/VineAndPlatform.html
+++ b/VineAndPlatform.html
@@ -850,7 +850,8 @@ function executeCuts(onComplete){
         moveAnglesTowards(targetAngles,dt);
         const tip=forwardKinematics(armAngles);
         const reached=tip.distanceTo(targetLocal)<0.05;
-        if((cutReachable && reached) || (!cutReachable && anglesClose(armAngles,targetAngles))) cutPhase='cut';
+        // In the real vineyard view, require the cutter to actually reach the target
+        if(reached || (state.viewMode !== 'real' && !cutReachable && anglesClose(armAngles,targetAngles))) cutPhase='cut';
       }else if(cutPhase==='cut'){
         applyCut(currentCut);
         saveCut(currentCut);


### PR DESCRIPTION
## Summary
- ensure cuts in real vineyard mode only execute when the robot cutter reaches the red marker

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b3ff9fd4832283ff8f61e0e8e54d