### PR TITLE
Allow cut execution when unreachable

### DIFF
--- a/VineAndPlatform.html
+++ b/VineAndPlatform.html
@@ -850,8 +850,8 @@ function executeCuts(onComplete){
         moveAnglesTowards(targetAngles,dt);
         const tip=forwardKinematics(armAngles);
         const reached=tip.distanceTo(targetLocal)<0.05;
-        // In the real vineyard view, require the cutter to actually reach the target
-        if(reached || (state.viewMode !== 'real' && !cutReachable && anglesClose(armAngles,targetAngles))) cutPhase='cut';
+        // If the arm can't quite reach, perform the cut once we've moved as close as possible
+        if(reached || (!cutReachable && anglesClose(armAngles,targetAngles))) cutPhase='cut';
       }else if(cutPhase==='cut'){
         applyCut(currentCut);
         saveCut(currentCut);


### PR DESCRIPTION
## Summary
- ensure cut replay continues even if the robot arm can't perfectly reach the target

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc243c088322893e891cbc771588